### PR TITLE
chore: release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/gacallea/freesound-credits/compare/v0.2.11...v0.2.12) - 2024-08-09
+
+### Other
+- update cargo-dist
+
 ## [0.2.11](https://github.com/gacallea/freesound-credits/compare/v0.2.10...v0.2.11) - 2024-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.11 -> 0.2.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.12](https://github.com/gacallea/freesound-credits/compare/v0.2.11...v0.2.12) - 2024-08-09

### Other
- update cargo-dist
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).