### PR TITLE
chore: release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⛰️  Features
 
-- Adding pre-commit hook for convetional - ([924c906](https://github.com/gacallea/freesound-credits/commit/924c906c4b662503d8e25199c44780608c323557)) by 
+- Adding pre-commit hook for convetional - ([924c906](https://github.com/gacallea/freesound-credits/commit/924c906c4b662503d8e25199c44780608c323557)) by
 
 ### 🐛 Bug Fixes
 
-- *(changelog)* Better template, less redundant, fix broken links - ([d2512ae](https://github.com/gacallea/freesound-credits/commit/d2512aeb81a63d7282f15f60fbc9bcc1f6daec60)) by 
-- *(changelog)* New template Closes [#22](https://github.com/gacallea/freesound-credits/pull/22) - ([2e421a9](https://github.com/gacallea/freesound-credits/commit/2e421a9db04693c5a388d05c411cac0565da7047)) by 
-- *(pre-commit)* Don't fix. it is unsigned - ([8b544cf](https://github.com/gacallea/freesound-credits/commit/8b544cf883c7f9b3e3bde1e61be6a086682545db)) by 
+- *(changelog)* Better template, less redundant, fix broken links - ([d2512ae](https://github.com/gacallea/freesound-credits/commit/d2512aeb81a63d7282f15f60fbc9bcc1f6daec60)) by
+- *(changelog)* New template Closes [#22](https://github.com/gacallea/freesound-credits/pull/22) - ([2e421a9](https://github.com/gacallea/freesound-credits/commit/2e421a9db04693c5a388d05c411cac0565da7047)) by
+- *(pre-commit)* Don't fix. it is unsigned - ([8b544cf](https://github.com/gacallea/freesound-credits/commit/8b544cf883c7f9b3e3bde1e61be6a086682545db)) by
 
 ### ⚙️ Miscellaneous Tasks
 
-- Update cargo-dist - ([b1cfa5b](https://github.com/gacallea/freesound-credits/commit/b1cfa5b6792293e10c4e117c3449cf4847cebb43)) by 
+- Update cargo-dist - ([b1cfa5b](https://github.com/gacallea/freesound-credits/commit/b1cfa5b6792293e10c4e117c3449cf4847cebb43)) by
 
 ## [0.2.11](https://github.com/gacallea/freesound-credits/compare/v0.2.10..v0.2.11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/gacallea/freesound-credits/compare/0.2.11..0.2.12)
+
+### ⛰️  Features
+
+- Adding pre-commit hook for convetional - ([924c906](https://github.com/gacallea/freesound-credits/commit/924c906c4b662503d8e25199c44780608c323557)) by 
+
+### 🐛 Bug Fixes
+
+- *(changelog)* Better template, less redundant, fix broken links - ([d2512ae](https://github.com/gacallea/freesound-credits/commit/d2512aeb81a63d7282f15f60fbc9bcc1f6daec60)) by 
+- *(changelog)* New template Closes [#22](https://github.com/gacallea/freesound-credits/pull/22) - ([2e421a9](https://github.com/gacallea/freesound-credits/commit/2e421a9db04693c5a388d05c411cac0565da7047)) by 
+- *(pre-commit)* Don't fix. it is unsigned - ([8b544cf](https://github.com/gacallea/freesound-credits/commit/8b544cf883c7f9b3e3bde1e61be6a086682545db)) by 
+
+### ⚙️ Miscellaneous Tasks
+
+- Update cargo-dist - ([b1cfa5b](https://github.com/gacallea/freesound-credits/commit/b1cfa5b6792293e10c4e117c3449cf4847cebb43)) by 
+
 ## [0.2.11](https://github.com/gacallea/freesound-credits/compare/v0.2.10..v0.2.11)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.11 -> 0.2.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.12](https://github.com/gacallea/freesound-credits/compare/0.2.11..0.2.12)

### ⛰️  Features

- Adding pre-commit hook for convetional - ([924c906](https://github.com/gacallea/freesound-credits/commit/924c906c4b662503d8e25199c44780608c323557)) by 

### 🐛 Bug Fixes

- *(changelog)* Better template, less redundant, fix broken links - ([d2512ae](https://github.com/gacallea/freesound-credits/commit/d2512aeb81a63d7282f15f60fbc9bcc1f6daec60)) by 
- *(changelog)* New template Closes [#22](https://github.com/gacallea/freesound-credits/pull/22) - ([2e421a9](https://github.com/gacallea/freesound-credits/commit/2e421a9db04693c5a388d05c411cac0565da7047)) by 
- *(pre-commit)* Don't fix. it is unsigned - ([8b544cf](https://github.com/gacallea/freesound-credits/commit/8b544cf883c7f9b3e3bde1e61be6a086682545db)) by 

### ⚙️ Miscellaneous Tasks

- Update cargo-dist - ([b1cfa5b](https://github.com/gacallea/freesound-credits/commit/b1cfa5b6792293e10c4e117c3449cf4847cebb43)) by
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).