### PR TITLE
fix(pre-commit): don't fix. it is unsigned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:
-      - id: markdownlint-fix
+      - id: markdownlint
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.4.0


### PR DESCRIPTION
markdownlint-fix solves an issue and creates another: its fixes are unsigned. all commits have to be signed off.