### PR TITLE
chore: release v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13](https://github.com/gacallea/freesound-credits/compare/v0.2.12..v0.2.13)
+
+### 🐛 Bug Fixes
+
+- *(release-plz)* Improvements all around ([#26](https://github.com/gacallea/freesound-credits/pull/26)) - ([7caf55f](https://github.com/gacallea/freesound-credits/commit/7caf55f3d681194a67cbcce13756cd4ec7c90a55))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(action)* Add commitlint on push main and PRs ([#28](https://github.com/gacallea/freesound-credits/pull/28)) - ([ea6064f](https://github.com/gacallea/freesound-credits/commit/ea6064f4d7e9213a19e8b75ec811f586e3e949a5))
+
 ## [0.2.12](https://github.com/gacallea/freesound-credits/compare/v0.2.11..v0.2.12)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.14"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.14"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.12 -> 0.2.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.13](https://github.com/gacallea/freesound-credits/compare/v0.2.12..v0.2.13)

### 🐛 Bug Fixes

- *(release-plz)* Improvements all around ([#26](https://github.com/gacallea/freesound-credits/pull/26)) - ([7caf55f](https://github.com/gacallea/freesound-credits/commit/7caf55f3d681194a67cbcce13756cd4ec7c90a55))

### ⚙️ Miscellaneous Tasks

- *(action)* Add commitlint on push main and PRs ([#28](https://github.com/gacallea/freesound-credits/pull/28)) - ([ea6064f](https://github.com/gacallea/freesound-credits/commit/ea6064f4d7e9213a19e8b75ec811f586e3e949a5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).