### PR TITLE
chore: release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/gacallea/freesound-credits/compare/v0.2.13...v0.2.14)
+
+### ⛰️ Features
+
+- *(readme)* Added commitlint badge + reoder ([#29](https://github.com/gacallea/freesound-credits/pull/29)) - ([7da5d62](https://github.com/gacallea/freesound-credits/commit/7da5d62f3db17c1229cd183fc7f72d3e5f3139e5))
+- *(release-plz)* Use release.link ([#35](https://github.com/gacallea/freesound-credits/pull/35)) - ([491f627](https://github.com/gacallea/freesound-credits/commit/491f62731568cb17814b4bbdbdb9eab50c4a1fc1))
+
+### 🐛 Bug Fixes
+
+- *(readme)* Renamed commitlint to .yml ([#31](https://github.com/gacallea/freesound-credits/pull/31)) - ([d5550ef](https://github.com/gacallea/freesound-credits/commit/d5550efe38d2d943382ca9dafe2ad9fe9ce48f3b))
+- *(release-plz)* Remote.link in links was broken ([#33](https://github.com/gacallea/freesound-credits/pull/33)) - ([ac12bc0](https://github.com/gacallea/freesound-credits/commit/ac12bc0cf2df64df935f8f1fbd6e2a3888f22ca6))
+
+### 📚 Documentation
+
+- *(readme)* Better wording. fix typos ([#34](https://github.com/gacallea/freesound-credits/pull/34)) - ([93cd500](https://github.com/gacallea/freesound-credits/commit/93cd500f8f41a378902d68cac4694162e25f2d73))
+
+### ⚙️ Miscellaneous Tasks
+
+- Improve precommit and workflows ([#36](https://github.com/gacallea/freesound-credits/pull/36)) - ([ff479c8](https://github.com/gacallea/freesound-credits/commit/ff479c81d22155f6a76db4148dabd45884760072))
+
 ## [0.2.13](https://github.com/gacallea/freesound-credits/compare/v0.2.12...v0.2.13)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "clap",
 ]
@@ -142,9 +142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "837a7e8026c6ce912ff01cefbe8cafc2f8010ac49682e2a3d9decc3bce1ecaaf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.13 -> 0.2.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.14](https://github.com/gacallea/freesound-credits/compare/v0.2.13...v0.2.14)

### ⛰️ Features

- *(readme)* Added commitlint badge + reoder ([#29](https://github.com/gacallea/freesound-credits/pull/29)) - ([7da5d62](https://github.com/gacallea/freesound-credits/commit/7da5d62f3db17c1229cd183fc7f72d3e5f3139e5))
- *(release-plz)* Use release.link ([#35](https://github.com/gacallea/freesound-credits/pull/35)) - ([491f627](https://github.com/gacallea/freesound-credits/commit/491f62731568cb17814b4bbdbdb9eab50c4a1fc1))

### 🐛 Bug Fixes

- *(readme)* Renamed commitlint to .yml ([#31](https://github.com/gacallea/freesound-credits/pull/31)) - ([d5550ef](https://github.com/gacallea/freesound-credits/commit/d5550efe38d2d943382ca9dafe2ad9fe9ce48f3b))
- *(release-plz)* Remote.link in links was broken ([#33](https://github.com/gacallea/freesound-credits/pull/33)) - ([ac12bc0](https://github.com/gacallea/freesound-credits/commit/ac12bc0cf2df64df935f8f1fbd6e2a3888f22ca6))

### 📚 Documentation

- *(readme)* Better wording. fix typos ([#34](https://github.com/gacallea/freesound-credits/pull/34)) - ([93cd500](https://github.com/gacallea/freesound-credits/commit/93cd500f8f41a378902d68cac4694162e25f2d73))

### ⚙️ Miscellaneous Tasks

- Improve precommit and workflows ([#36](https://github.com/gacallea/freesound-credits/pull/36)) - ([ff479c8](https://github.com/gacallea/freesound-credits/commit/ff479c81d22155f6a76db4148dabd45884760072))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).