### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15](https://github.com/gacallea/freesound-credits/compare/v0.2.14...v0.2.15)
+
+### ⛰️ Features
+
+- *(spellcheck)* Add spellcheck precommit ci and config ([#39](https://github.com/gacallea/freesound-credits/pull/39)) - ([727e79e](https://github.com/gacallea/freesound-credits/commit/727e79edea0a0fe902fa9a5dfb63a90f5a621992))
+
+### 🐛 Bug Fixes
+
+- *(spellcheck)* +top number -precomit ([#40](https://github.com/gacallea/freesound-credits/pull/40)) - ([139ffc9](https://github.com/gacallea/freesound-credits/commit/139ffc90b774bb292f7030f0e07e3e472543a8d6))
+- Streamline pipelines ([#42](https://github.com/gacallea/freesound-credits/pull/42)) - ([f8f33e8](https://github.com/gacallea/freesound-credits/commit/f8f33e89092727cc19a844bc81f6d1a31e911570))
+- Rm redundant freesound in frontmatter ([#41](https://github.com/gacallea/freesound-credits/pull/41)) - ([e9c24a9](https://github.com/gacallea/freesound-credits/commit/e9c24a92a653dc41a1aab0ea3f055a101fa16249))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(docs)* GitHub templates improve ([#45](https://github.com/gacallea/freesound-credits/pull/45)) ([#47](https://github.com/gacallea/freesound-credits/pull/47)) - ([4ddb88e](https://github.com/gacallea/freesound-credits/commit/4ddb88eb55e537368f10b404d05e6476b01eb506))
+- *(readme)* Add licenses badges and remove written line ([#37](https://github.com/gacallea/freesound-credits/pull/37)) - ([040b8d0](https://github.com/gacallea/freesound-credits/commit/040b8d0c5eb87ea4ad26b66bc62154fb3b12006e))
+
 ## [0.2.14](https://github.com/gacallea/freesound-credits/compare/v0.2.13...v0.2.14)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "clap",
 ]
@@ -142,9 +142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.73"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837a7e8026c6ce912ff01cefbe8cafc2f8010ac49682e2a3d9decc3bce1ecaaf"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.14 -> 0.2.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.15](https://github.com/gacallea/freesound-credits/compare/v0.2.14...v0.2.15)

### ⛰️ Features

- *(spellcheck)* Add spellcheck precommit ci and config ([#39](https://github.com/gacallea/freesound-credits/pull/39)) - ([727e79e](https://github.com/gacallea/freesound-credits/commit/727e79edea0a0fe902fa9a5dfb63a90f5a621992))

### 🐛 Bug Fixes

- *(spellcheck)* +top number -precomit ([#40](https://github.com/gacallea/freesound-credits/pull/40)) - ([139ffc9](https://github.com/gacallea/freesound-credits/commit/139ffc90b774bb292f7030f0e07e3e472543a8d6))
- Streamline pipelines ([#42](https://github.com/gacallea/freesound-credits/pull/42)) - ([f8f33e8](https://github.com/gacallea/freesound-credits/commit/f8f33e89092727cc19a844bc81f6d1a31e911570))
- Rm redundant freesound in frontmatter ([#41](https://github.com/gacallea/freesound-credits/pull/41)) - ([e9c24a9](https://github.com/gacallea/freesound-credits/commit/e9c24a92a653dc41a1aab0ea3f055a101fa16249))

### ⚙️ Miscellaneous Tasks

- *(docs)* GitHub templates improve ([#45](https://github.com/gacallea/freesound-credits/pull/45)) ([#47](https://github.com/gacallea/freesound-credits/pull/47)) - ([4ddb88e](https://github.com/gacallea/freesound-credits/commit/4ddb88eb55e537368f10b404d05e6476b01eb506))
- *(readme)* Add licenses badges and remove written line ([#37](https://github.com/gacallea/freesound-credits/pull/37)) - ([040b8d0](https://github.com/gacallea/freesound-credits/commit/040b8d0c5eb87ea4ad26b66bc62154fb3b12006e))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).