### PR TITLE
chore: release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17](https://github.com/gacallea/freesound-credits/compare/v0.2.16...v0.2.17)
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.lock dependencies - ([0000000](https://github.com/gacallea/freesound-credits/commit/0000000))
+
 ## [0.2.16](https://github.com/gacallea/freesound-credits/compare/v0.2.15...v0.2.16)
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "freesound-credits"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "clap",
 ]
@@ -118,9 +118,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -142,9 +142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freesound-credits"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## 🤖 New release
* `freesound-credits`: 0.2.16 -> 0.2.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.17](https://github.com/gacallea/freesound-credits/compare/v0.2.16...v0.2.17)

### ⚙️ Miscellaneous Tasks

- Update Cargo.lock dependencies - ([0000000](https://github.com/gacallea/freesound-credits/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).